### PR TITLE
fix support for es v8.*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,4 @@ RUN npm install
 ADD index.js /usr/src/index.js
 ADD plugins /usr/src/plugins
 
-ENTRYPOINT ["/bin/sh" "-c" "node"]
-
-CMD ["/bin/sh" "-c" "/usr/src/index.js"]
+CMD ["node", "/usr/src/index.js"]

--- a/index.js
+++ b/index.js
@@ -45,7 +45,6 @@ const Plugins = {
 const run = async () => {
   const unroutedAlerts = await es.search({
     index: ELASTICSEARCH_ALERT_INDEX,
-    type: '_doc',
     size: 10000,
     body: {
       sort: [{ "@timestamp" : "asc" }],


### PR DESCRIPTION
support for 'type' is removed in ES version 8

https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html

FYI @bdentino 